### PR TITLE
Add web UI scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# Performance_Dashboard
+# Performance Dashboard
+
+This project provides a small FastAPI backend and a React frontend for exploring membership metrics.
+
+## Setup
+
+### Backend
+
+1. Install dependencies:
+   ```bash
+   pip install -r api/requirements.txt
+   ```
+2. Start the API:
+   ```bash
+   uvicorn api.app:app --reload
+   ```
+
+The API will run on `http://localhost:8000` by default and exposes `/metrics`.
+
+### Frontend
+
+1. Install Node dependencies:
+   ```bash
+   cd frontend
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+The React application will be available at `http://localhost:5173` and proxies API requests to the backend.
+
+### Building for Production
+
+To build the frontend for production:
+
+```bash
+npm run build
+```
+
+### Notes
+
+The previous command line interface is no longer emphasized. Use the web UI instead to view metrics.

--- a/api/analysis.py
+++ b/api/analysis.py
@@ -1,0 +1,10 @@
+# Simple analysis module
+
+def get_membership_metrics():
+    """Return aggregated membership metrics."""
+    # Placeholder implementation
+    return {
+        'active_members': 120,
+        'inactive_members': 30,
+        'total_members': 150
+    }

--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,3 @@
+from .main import app
+
+# For `uvicorn api.app:app --reload`

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+from .analysis import get_membership_metrics
+
+app = FastAPI()
+
+@app.get('/metrics')
+def read_metrics():
+    return get_membership_metrics()

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+/dist

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Performance Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "performance-dashboard-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+function App() {
+  const [metrics, setMetrics] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/metrics')
+      .then((res) => res.json())
+      .then(setMetrics)
+      .catch((err) => console.error('Failed to load metrics', err));
+  }, []);
+
+  return (
+    <div>
+      <h1>Membership Metrics</h1>
+      {metrics ? (
+        <pre>{JSON.stringify(metrics, null, 2)}</pre>
+      ) : (
+        <p>Loading...</p>
+      )}
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold React app under `frontend/`
- add FastAPI backend with `analysis` module
- document setup in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6864310915c48323977f36d018a8c0c0