### PR TITLE
Use dateutil relativedelta for month offsets

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+python-dateutil

--- a/main.py
+++ b/main.py
@@ -1,0 +1,28 @@
+import argparse
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
+from src.analysis import get_membership_metrics
+
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser(description="Display membership metrics")
+    parser.add_argument("--months", type=int, default=1,
+                        help="Number of months of data to include")
+    return parser.parse_args(args)
+
+
+def calculate_since_date(months, *, now=None):
+    now = now or datetime.now()
+    return now - relativedelta(months=months)
+
+
+def main(args=None):
+    args = parse_args(args)
+    since = calculate_since_date(args.months)
+    metrics = get_membership_metrics()
+    print(f"Metrics since {since.date()}: {metrics}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
+from main import calculate_since_date, parse_args
+
+
+def test_calculate_since_date():
+    now = datetime(2024, 1, 31, 12, 0, 0)
+    result = calculate_since_date(2, now=now)
+    assert result == now - relativedelta(months=2)
+
+
+def test_parse_args_default():
+    args = parse_args([])
+    assert args.months == 1
+
+
+def test_parse_args_value():
+    args = parse_args(["--months", "3"])
+    assert args.months == 3


### PR DESCRIPTION
## Summary
- add `python-dateutil` to backend dependencies
- implement a simple CLI in `main.py` using `relativedelta`
- add basic tests for the new CLI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_b_6864d8288360832380a8d0a8a67ee3f3