### PR TITLE
Fix API route to match frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project provides a small FastAPI backend and a React frontend for exploring
    uvicorn api.app:app --reload
    ```
 
-The API will run on `http://localhost:8000` by default and exposes `/metrics`.
+The API will run on `http://localhost:8000` by default and exposes `/api/metrics`.
 
 ### Frontend
 

--- a/api/main.py
+++ b/api/main.py
@@ -3,6 +3,6 @@ from src.analysis import get_membership_metrics
 
 app = FastAPI()
 
-@app.get('/metrics')
+@app.get('/api/metrics')
 def read_metrics():
     return get_membership_metrics()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+from api.main import app
+
+
+def test_metrics_endpoint():
+    client = TestClient(app)
+    resp = client.get('/api/metrics')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['active_members'] == 120
+    assert data['inactive_members'] == 30
+    assert data['total_members'] == 150


### PR DESCRIPTION
## Summary
- correct API route path `/api/metrics`
- update README for new path
- add regression test covering `/api/metrics`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_68664e3d6d3883238b8d19c79eb041cd